### PR TITLE
Disable horizontal overflow

### DIFF
--- a/css/nav-marquee.css
+++ b/css/nav-marquee.css
@@ -10,8 +10,9 @@
 
 body {
   margin: 0;
-  --color-text: #111;
   --color-bg: #111;
+  --color-text: #111;
+  overflow-x: hidden;
   --color-link: #b19e7f;
   --color-link-hover: #000;
   color: var(--color-text);


### PR DESCRIPTION
Disables horizontal overflow on the size. A horizontal scrollbar appears once you reach the navigation bar. The bar itself doesn't move much of anything, and restricting the widths of the containers/elements did nothing. Simply disabling the scrolling functionality helps clean up the browser UI and ensure that those using touchscreen devices aren't angered by horizontal movement.